### PR TITLE
Create UpdateCraftCommand.php

### DIFF
--- a/src/Command/UpdateCraftCommand.php
+++ b/src/Command/UpdateCraftCommand.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace CraftCli\Command;
+
+use CraftCli\Support\TarExtractor;
+use CraftCli\Support\Downloader\TempDownloader;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+use Exception;
+use CFileHelper;
+
+class UpdateCraftCommand extends Command
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected $name = 'update';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $description = 'Update Craft.';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getArguments()
+    {
+        return array(
+            array(
+                'path',
+                InputArgument::OPTIONAL,
+                'Specify an installation path. Defaults to the current working directory.',
+            ),
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getOptions()
+    {
+        return array(
+            array(
+                'terms', // name
+                't', // shortcut
+                InputOption::VALUE_NONE, // mode
+                'I agree to the terms and conditions (https://buildwithcraft.com/license)', // description
+                null, // default value
+            ),
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function fire()
+    {
+        $path = rtrim($this->argument('path'), DIRECTORY_SEPARATOR) ?: getcwd();
+
+        if (! $this->option('terms') && ! $this->confirm('I agree to the terms and conditions (https://buildwithcraft.com/license)')) {
+            $this->error('You did not agree to the terms and conditions (https://buildwithcraft.com/license)');
+
+            return;
+        }
+
+        $url = 'http://buildwithcraft.com/latest.tar.gz?accept_license=yes';
+
+        $this->comment('Downloading...');
+
+        $downloader = new TempDownloader($url, '.tar.gz');
+
+        $downloader->setOutput($this->output);
+
+        try {
+            $filePath = $downloader->download();
+        } catch (Exception $e) {
+            $this->error($e->getMessage());
+
+            return;
+        }
+
+        $this->comment('Extracting...');
+
+        $tmp = getcwd().uniqid('/.tmp-');
+
+        @mkdir($tmp, 0777, true);
+
+        $tarExtractor = new TarExtractor($filePath, $tmp);
+
+        $tarExtractor->extract();
+
+        CFileHelper::copyDirectory($tmp.'/craft/app', $path.'/craft/app');
+
+        CFileHelper::removeDirectory($tmp);
+
+        $this->comment('Running migrations...');
+
+        craft()->updates->updateDatabase('craft');
+
+        $this->info('Update complete!');
+    }
+}


### PR DESCRIPTION
This is mostly copied from the installation command. It only updates the `app` directory and then runs updates on Craft using `craft()->updates->updateDatabase('craft');`. 

I thought about abstracting some of the duplicate code from this and the install command to a `Downloadable` trait, but I couldn't really think of another case that would benefit from this abstraction. It was simpler to just have a few lines in both methods that are mostly the same.

Before this is merged in, the command should be tested some more against a couple of older builds. However, I wanted to go ahead and get some additional eyes on this and see if anything should be added or improved upon.
