### PR TITLE
Use Craft globals for app, framework and vendor paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,6 @@
         "xamin/handlebars.php": "0.10.*",
         "composer/ca-bundle": "^1.0",
         "vlucas/phpdotenv": "~2.4",
-        "craft-cli/bootstrap": "^0.1.0"
+        "craft-cli/bootstrap": "dev-master"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,6 @@
         "xamin/handlebars.php": "0.10.*",
         "composer/ca-bundle": "^1.0",
         "vlucas/phpdotenv": "~2.4",
-        "craft-cli/bootstrap": "0.2.0"
+        "craft-cli/bootstrap": "^0.2.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,6 @@
         "xamin/handlebars.php": "0.10.*",
         "composer/ca-bundle": "^1.0",
         "vlucas/phpdotenv": "~2.4",
-        "craft-cli/bootstrap": "dev-master"
+        "craft-cli/bootstrap": "0.2.0"
     }
 }

--- a/sample.craft-cli.php
+++ b/sample.craft-cli.php
@@ -13,13 +13,31 @@ if (php_sapi_name() !== 'cli') {
 
 return array(
     /**
-     * Craft path
+     * Craft base path
      *
      * Specify the path to your craft folder
      * If you leave this blank, it will assume your
      * folder is <current directory>/craft
      */
     'craft_path' => __DIR__.'/craft',
+    
+    /**
+     * Craft app path
+     *
+     * Specify the path to your craft app folder
+     * If you leave this blank, it will assume your
+     * folder is <current directory>/craft/app
+     */
+    'craft_app_path' => null,
+
+    /**
+     * Craft framework path
+     *
+     * Specify the path to your Yii framework folder
+     * If you leave this blank, it will assume your
+     * folder is <current directory>/craft/app/framework
+     */
+    'craft_framework_path' => null,
 
     /**
      * Craft config path

--- a/src/Application.php
+++ b/src/Application.php
@@ -320,6 +320,10 @@ class Application extends ConsoleApplication
         if (isset($config['craft_translations_path'])) {
             define('CRAFT_TRANSLATIONS_PATH', rtrim($config['craft_translations_path'], '/').'/');
         }
+        
+        if (isset($this->vendorPath)) {
+            define('CRAFT_VENDOR_PATH', $this->vendorPath);
+        }
 
         // Add user-defined commands from config
         if (isset($config['commands']) && is_array($config['commands'])) {

--- a/src/Application.php
+++ b/src/Application.php
@@ -296,6 +296,10 @@ class Application extends ConsoleApplication
             $this->appPath = $config['craft_app_path'];
             define('CRAFT_APP_PATH', rtrim($config['craft_app_path'], '/').'/');
         }
+        
+        if (isset($config['craft_framework_path'])) {
+            define('CRAFT_FRAMEWORK_PATH', rtrim($config['craft_framework_path'], '/').'/');
+        }
 
         if (isset($config['craft_config_path'])) {
             define('CRAFT_CONFIG_PATH', rtrim($config['craft_config_path'], '/').'/');

--- a/src/Application.php
+++ b/src/Application.php
@@ -62,6 +62,12 @@ class Application extends ConsoleApplication
     protected $craftPath = 'craft';
 
     /**
+     * Path to the Craft app folder
+     * @var string
+     */
+    protected $appPath;
+
+    /**
      * Path to the Composer vendor folder
      * @var string
      */
@@ -164,7 +170,7 @@ class Application extends ConsoleApplication
      */
     public function canBeBootstrapped()
     {
-        return file_exists($this->craftPath.'/app/Craft.php');
+        return file_exists($this->appPath.'/Craft.php');
     }
 
     /**
@@ -175,6 +181,7 @@ class Application extends ConsoleApplication
     public function bootstrap($isInstalling = false)
     {
         $craftPath = $this->craftPath;
+        $appPath = $this->appPath;
 
         if ($this->vendorPath) {
             return require $this->vendorPath.'/craft-cli/bootstrap/src/bootstrap-craft2.php';
@@ -283,6 +290,11 @@ class Application extends ConsoleApplication
 
         if ($environment) {
             define('CRAFT_ENVIRONMENT', $environment);
+        }
+
+        if (isset($config['craft_app_path'])) {
+            $this->appPath = $config['craft_app_path'];
+            define('CRAFT_APP_PATH', rtrim($config['craft_app_path'], '/').'/');
         }
 
         if (isset($config['craft_config_path'])) {

--- a/src/Application.php
+++ b/src/Application.php
@@ -65,7 +65,7 @@ class Application extends ConsoleApplication
      * Path to the Craft app folder
      * @var string
      */
-    protected $appPath;
+    protected $appPath = 'craft/app';
 
     /**
      * Path to the Composer vendor folder


### PR DESCRIPTION
Currently the console application class makes some assumptions about where the Craft app and Yii framework directories live that is incompatible with installing those libraries as dependencies of a project via Composer. For example

```php
file_exists($this->craftPath.'/app/Craft.php');
```

assumes that the Craft base path will contain the `app` directory beneath it, but this is not the case if you install Craft 2 via composer. Instead it would reside in `vendor/craftcms/cms/src`. Similarly, the Yii framework is installed as a dependency of the `craftcms/cms` Composer package and would install to `vendor/yiisoft/yii/framework`. This pull request makes the following changes to make the configuration flexible enough to accommodate the Composer install use case:

* Adds an instance variable to assign the Craft app path independently of the Craft base path
* Adds code to handle a `craft_app_path` configuration option (needs documentation)
* Adds code to handle a `craft_framework_path` configuration option (needs documentation)
* Defines global variables `CRAFT_APP_PATH`, `CRAFT_FRAMEWORK_PATH` and `CRAFT_VENDOR_PATH` for use in the bootstrap script

This pull request relates closely to changes I submitted to the bootstrap script: rsanchez/craft-cli-bootstrap/pull/1.

N.B. I temporarily had to set the version dependency for `craft-cli/bootstrap` to `dev-master` so that I could get this working with my project code. Let me know if/how you would want me to adjust this if you want to merge the code into your repo.