### PR TITLE
Allow task type to be specified as parameter to run:tasks

### DIFF
--- a/src/Command/RunTasksCommand.php
+++ b/src/Command/RunTasksCommand.php
@@ -44,6 +44,12 @@ class RunTasksCommand extends Command
                 InputOption::VALUE_NONE,
                 'Reset failed tasks',
             ),
+            array(
+                'type',
+                't',
+                InputOption::VALUE_OPTIONAL,
+                'Run tasks of this type'
+            ),
         );
     }
 
@@ -61,6 +67,12 @@ class RunTasksCommand extends Command
         }
 
         foreach ($tasks as $task) {
+            if ($this->option('type') !== null) {
+                // Iterate to next item if input type does not match the task type
+                if ($this->option('type') != $task->type) {
+                    continue;
+                }
+            }
             if ($task->status === TaskStatus::Running) {
                 if ($this->option('reset-running')) {
                     $this->resetTask($task);


### PR DESCRIPTION
It is not optimal in that way that it have to call `$this->craft->tasks->getAllTasks();`

I had hoped that I would be able to use the `$this->craft->tasks->getPendingTasks($type)` method, but that would break the ability to reset running and failed tasks. 
I assume that keeping those is more important than saving a few `continue` inside the `foreach` loop, but let me know if you want me to change anything